### PR TITLE
Refactor indexing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,4 +26,4 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - name: Test
-        run: go test ./...  -timeout 3s
+        run: go test ./...  -timeout 3s -race

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,4 +26,4 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - name: Test
-        run: go test ./...
+        run: go test ./...  -timeout 3s

--- a/library/index/file_record.go
+++ b/library/index/file_record.go
@@ -1,0 +1,9 @@
+package index
+
+type FileOnDiskRecord struct {
+	Path    string
+	TitleID uint64
+	Version uint32
+	Name    string
+	Size    int64
+}

--- a/library/index/title_record.go
+++ b/library/index/title_record.go
@@ -2,7 +2,6 @@ package index
 
 //TitleOnDiskCollection is a semi-logical grouping of titles on disk
 type TitleOnDiskCollection struct {
-	// sync.RWMutex
 	BaseTitle *FileOnDiskRecord
 	Update    *FileOnDiskRecord
 	DLC       []FileOnDiskRecord

--- a/library/index/title_record.go
+++ b/library/index/title_record.go
@@ -1,0 +1,23 @@
+package index
+
+//TitleOnDiskCollection is a semi-logical grouping of titles on disk
+type TitleOnDiskCollection struct {
+	// sync.RWMutex
+	BaseTitle *FileOnDiskRecord
+	Update    *FileOnDiskRecord
+	DLC       []FileOnDiskRecord
+}
+
+//Returns all the files in the collection
+func (r *TitleOnDiskCollection) GetFiles() []FileOnDiskRecord {
+	values := []FileOnDiskRecord{}
+	if r.BaseTitle != nil {
+		values = append(values, *r.BaseTitle)
+	}
+	if r.Update != nil {
+		values = append(values, *r.Update)
+	}
+
+	values = append(values, r.DLC...)
+	return values
+}

--- a/library/index/title_record_test.go
+++ b/library/index/title_record_test.go
@@ -1,0 +1,19 @@
+package index
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGetFiles(t *testing.T) {
+	itm := TitleOnDiskCollection{
+		BaseTitle: &FileOnDiskRecord{Path: "111"},
+		Update:    &FileOnDiskRecord{Path: "222"},
+		DLC:       []FileOnDiskRecord{{Path: "333"}, {Path: "444"}},
+	}
+	files := itm.GetFiles()
+	expected := []FileOnDiskRecord{{Path: "111"}, {Path: "222"}, {Path: "333"}, {Path: "444"}}
+	if !reflect.DeepEqual(files, expected) {
+		t.Errorf("Failed, wanted %v, got %v", expected, files)
+	}
+}

--- a/library/library.go
+++ b/library/library.go
@@ -56,6 +56,8 @@ type Library struct {
 	fileCompressionRequests chan *fileScanningInfo
 	exit                    chan bool
 	ui                      *termui.TermUI
+
+	organisationLocking organisationLocks
 }
 
 func NewLibrary(titledb *titledb.TitlesDB, settings *settings.Settings, ui *termui.TermUI) *Library {
@@ -73,6 +75,7 @@ func NewLibrary(titledb *titledb.TitlesDB, settings *settings.Settings, ui *term
 		exit:                       make(chan bool, 10),
 		FileIndex:                  index.NewIndex(titledb, settings),
 		waitgroup:                  &sync.WaitGroup{},
+		organisationLocking:        organisationLocks{},
 	}
 
 	return library

--- a/library/library.go
+++ b/library/library.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ralim/switchhost/formats"
 	"github.com/ralim/switchhost/keystore"
+	"github.com/ralim/switchhost/library/index"
 	"github.com/ralim/switchhost/settings"
 	"github.com/ralim/switchhost/termui"
 	"github.com/ralim/switchhost/titledb"
@@ -32,12 +33,12 @@ type fileScanningInfo struct {
 
 // Library manages the representation of the game files on disk + their metadata
 type Library struct {
+	FileIndex *index.Index
+
 	//Privates
 	keys     *keystore.Keystore
 	settings *settings.Settings
 	titledb  *titledb.TitlesDB
-
-	filesKnown map[uint64]TitleOnDiskCollection
 
 	waitgroup *sync.WaitGroup
 	//These channels are used for decoupling the workers for each state of the file import pipeline
@@ -70,9 +71,8 @@ func NewLibrary(titledb *titledb.TitlesDB, settings *settings.Settings, ui *term
 		fileCompressionRequests:    make(chan *fileScanningInfo, settings.QueueLength),
 		folderCleanupRequests:      make(chan string, settings.QueueLength),
 		exit:                       make(chan bool, 10),
-
-		filesKnown: make(map[uint64]TitleOnDiskCollection),
-		waitgroup:  &sync.WaitGroup{},
+		FileIndex:                  index.NewIndex(titledb, settings),
+		waitgroup:                  &sync.WaitGroup{},
 	}
 
 	return library

--- a/library/library.go
+++ b/library/library.go
@@ -108,13 +108,6 @@ func (lib *Library) Start() {
 		}
 
 	}
-	// Run first file scan in background
-	lib.waitgroup.Add(1)
-	go lib.RunScan()
-
-	// Start worker thread for handling file parsing
-	lib.waitgroup.Add(1)
-	go lib.fileorganisationWorker()
 
 	// Internal states of the chain (except organisation) run multiple workers to utilise more cores
 	// Process up to CPU count steps at once for each type
@@ -125,6 +118,10 @@ func (lib *Library) Start() {
 
 		lib.waitgroup.Add(1)
 		go lib.fileValidationWorker()
+
+		// Start worker thread for handling file parsing
+		lib.waitgroup.Add(1)
+		go lib.fileorganisationWorker()
 	}
 
 	// Start worker for cleaning up empty folders
@@ -134,6 +131,10 @@ func (lib *Library) Start() {
 	// Start worker for nsz compression
 	lib.waitgroup.Add(1)
 	go lib.compressionWorker()
+
+	// Run first file scan in background
+	lib.waitgroup.Add(1)
+	go lib.RunScan()
 
 }
 

--- a/library/library.go
+++ b/library/library.go
@@ -15,9 +15,6 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// Channel depth is a tradeoff between RAM utiisation and ability to tolerate bursts of uploads
-const ChannelDepth int = 64
-
 // This struct is used for all of the file ingest scanning path.
 // The data in the struct is slowly filled in
 type fileScanningInfo struct {
@@ -67,11 +64,11 @@ func NewLibrary(titledb *titledb.TitlesDB, settings *settings.Settings, ui *term
 		ui:       ui,
 		keys:     nil,
 		// Channels
-		fileMetaScanRequests:       make(chan *fileScanningInfo, ChannelDepth),
-		fileValidationScanRequests: make(chan *fileScanningInfo, ChannelDepth),
-		fileOrganisationRequests:   make(chan *fileScanningInfo, ChannelDepth),
-		fileCompressionRequests:    make(chan *fileScanningInfo, ChannelDepth),
-		folderCleanupRequests:      make(chan string, ChannelDepth),
+		fileMetaScanRequests:       make(chan *fileScanningInfo, settings.QueueLength),
+		fileValidationScanRequests: make(chan *fileScanningInfo, settings.QueueLength),
+		fileOrganisationRequests:   make(chan *fileScanningInfo, settings.QueueLength),
+		fileCompressionRequests:    make(chan *fileScanningInfo, settings.QueueLength),
+		folderCleanupRequests:      make(chan string, settings.QueueLength),
 		exit:                       make(chan bool, 10),
 
 		filesKnown: make(map[uint64]TitleOnDiskCollection),

--- a/library/library_test.go
+++ b/library/library_test.go
@@ -17,6 +17,7 @@ func TestStopStart(t *testing.T) {
 	t.Parallel()
 	sett := settings.Settings{
 		NSZCommandLine: "sleep 0.1",
+		QueueLength:    2,
 	}
 	lib := NewLibrary(nil, &sett, nil)
 

--- a/library/organisation_locks.go
+++ b/library/organisation_locks.go
@@ -1,0 +1,31 @@
+package library
+
+import (
+	"sync"
+
+	"github.com/rs/zerolog/log"
+)
+
+type organisationLocks struct {
+	// To allow multiple organisation (aka file moving) threads to run concurrently we need a way of locking a _titleID_ for each thread.
+	_              sync.Mutex
+	lockedTitleIDs sync.Map
+}
+
+func (org *organisationLocks) Lock(titleID uint64) {
+	titleID = titleID & 0xFFFFFFFFFFFFE000 // Strip back to base titleID
+	value, _ := org.lockedTitleIDs.LoadOrStore(titleID, &sync.Mutex{})
+	mtx := value.(*sync.Mutex)
+	mtx.Lock()
+}
+
+func (org *organisationLocks) Unlock(titleID uint64) {
+
+	titleID = titleID & 0xFFFFFFFFFFFFE000 // Strip back to base titleID
+	value, ok := org.lockedTitleIDs.Load(titleID)
+	if !ok {
+		log.Fatal().Msg("Unlock received for missing titleID")
+	}
+	mtx := value.(*sync.Mutex)
+	mtx.Unlock()
+}

--- a/server/file.go
+++ b/server/file.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ralim/switchhost/library"
+	"github.com/ralim/switchhost/library/index"
 	"github.com/ralim/switchhost/utilities"
 )
 
@@ -23,7 +23,7 @@ var ErrInvalidPath error = errors.New("invalid path")
 
 // Given valid input, these two functions are each others inverse
 
-func (server *Server) GenerateVirtualFilePath(file library.FileOnDiskRecord, hostNameToUse string, useHTTPS bool) string {
+func (server *Server) GenerateVirtualFilePath(file index.FileOnDiskRecord, hostNameToUse string, useHTTPS bool) string {
 	ext := path.Ext(file.Path)
 	ext = strings.ToLower(ext)
 	fileFinalName := fmt.Sprintf("%s [%016X][v%d]%s", utilities.CleanName(file.Name), file.TitleID, file.Version, ext)
@@ -58,7 +58,7 @@ func (server *Server) getFileFromVirtualPath(path string) (io.ReadSeekCloser, st
 		return nil, "", 0, fmt.Errorf("couldn't interpret path %s - %w", path, err)
 	}
 	//Otherwise we can now look up the actual on disk path to said file
-	info, ok := server.library.GetFileRecord(titleID, version)
+	info, ok := server.library.FileIndex.GetFileRecord(titleID, version)
 	if !ok {
 		return nil, "", 0, fmt.Errorf("couldn't lookup path %s", path)
 	}

--- a/server/http_test.go
+++ b/server/http_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/ralim/switchhost/library"
+	"github.com/ralim/switchhost/library/index"
 	"github.com/ralim/switchhost/settings"
 	"github.com/ralim/switchhost/titledb"
 )
@@ -45,13 +46,13 @@ func TestHTTPServerbasics(t *testing.T) {
 		t.Errorf("response doesnt match expected >%s<", response)
 	}
 	//Now insert a game into the library and run tests with content
-	file := &library.FileOnDiskRecord{
+	file := &index.FileOnDiskRecord{
 		Path:    "../testing_files/UnitTest_[05123A0000000000].nsp",
 		TitleID: 0x05123A0000000000,
 		Version: 0x0,
 		Name:    "UnitTest",
 	}
-	lib.AddFileRecord(file)
+	lib.FileIndex.AddFileRecord(file)
 	err = server.generateFileJSONPayload(tempBuffer, "test", false, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -105,13 +106,13 @@ func TestHTTPFileServingBinary(t *testing.T) {
 	server, lib, temp_folder := maketestServer(t)
 	defer os.RemoveAll(temp_folder)
 
-	file := &library.FileOnDiskRecord{
+	file := &index.FileOnDiskRecord{
 		Path:    "../testing_files/UnitTest_[05123A0000000000].nsp",
 		TitleID: 0x05123A0000000000,
 		Version: 0x0,
 		Name:    "UnitTest",
 	}
-	lib.AddFileRecord(file)
+	lib.FileIndex.AddFileRecord(file)
 
 	req, err := http.NewRequest("GET", "vfile/365418291444842496/0/data.bin", nil)
 	if err != nil {
@@ -146,13 +147,13 @@ func TestHTTPFileServingBinaryRangeBytes(t *testing.T) {
 	server, lib, temp_folder := maketestServer(t)
 	defer os.RemoveAll(temp_folder)
 
-	file := &library.FileOnDiskRecord{
+	file := &index.FileOnDiskRecord{
 		Path:    "../testing_files/UnitTest_[05123A0000000000].nsp",
 		TitleID: 0x05123A0000000000,
 		Version: 0x0,
 		Name:    "UnitTest",
 	}
-	lib.AddFileRecord(file)
+	lib.FileIndex.AddFileRecord(file)
 
 	req, err := http.NewRequest("GET", "vfile/365418291444842496/0/data.bin", nil)
 	if err != nil {

--- a/server/json.go
+++ b/server/json.go
@@ -35,9 +35,9 @@ func (server *Server) generateFileJSONPayload(writer io.Writer, hostNameToUse st
 		response.MOTD = &server.settings.ServerMOTD
 	}
 
-	for _, file := range server.library.ListFiles() {
+	for _, file := range server.library.FileIndex.ListFiles() {
 		response.Files = append(response.Files, fileEntry{URL: server.GenerateVirtualFilePath(file, hostNameToUse, useHTTPS), Size: file.Size, Name: utilities.CleanName(file.Name)})
-		fileinfo, ok := server.library.LookupFileInfo(file)
+		fileinfo, ok := server.library.FileIndex.LookupFileInfo(file)
 		if ok {
 			response.TitleDB[fileinfo.StringID] = fileinfo
 		}

--- a/server/virtualftp/ftp.go
+++ b/server/virtualftp/ftp.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/ralim/switchhost/library"
+	"github.com/ralim/switchhost/library/index"
 	"github.com/ralim/switchhost/settings"
 	"github.com/ralim/switchhost/utilities"
 	"github.com/rs/zerolog/log"
@@ -89,7 +90,7 @@ func (driver *FTPDriver) dirPathToTitleID(path string) (uint64, error) {
 	return 0, errors.New("couldnt parse")
 }
 
-func (driver *FTPDriver) getFakeFolderFileInfo(titleInfo library.FileOnDiskRecord) os.FileInfo {
+func (driver *FTPDriver) getFakeFolderFileInfo(titleInfo index.FileOnDiskRecord) os.FileInfo {
 	virtualpath := fmt.Sprintf("%s [%d]", utilities.CleanName(titleInfo.Name), titleInfo.TitleID)
 	info := NewFakeFolder(virtualpath)
 	return &info
@@ -99,14 +100,14 @@ func (driver *FTPDriver) getFakeFolderFileInfo(titleInfo library.FileOnDiskRecor
 func (driver *FTPDriver) ListDir(ctx *ftpserver.Context, path string, callback func(os.FileInfo) error) error {
 	if path == "/" {
 		//Returning virtual folder of titles
-		for _, titleInfo := range driver.library.ListTitleFiles() {
+		for _, titleInfo := range driver.library.FileIndex.ListTitleFiles() {
 			//Generate title virtual path
 			_ = callback(driver.getFakeFolderFileInfo(titleInfo))
 		}
 	} else {
 		//Most likely a path to a folder of files
 		if titleID, err := driver.dirPathToTitleID(path); err == nil {
-			val, ok := driver.library.GetFilesForTitleID(titleID)
+			val, ok := driver.library.FileIndex.GetFilesForTitleID(titleID)
 			if ok {
 				//Now need to yield os info's for all of the underlying files
 				for _, file := range val.GetFiles() {
@@ -121,7 +122,7 @@ func (driver *FTPDriver) ListDir(ctx *ftpserver.Context, path string, callback f
 	}
 	return nil
 }
-func (driver *FTPDriver) getfakepathForRealFile(file library.FileOnDiskRecord) string {
+func (driver *FTPDriver) getfakepathForRealFile(file index.FileOnDiskRecord) string {
 	ext := path.Ext(file.Path)
 	fileTitle := fmt.Sprintf("%s - [%d][%d]%s", file.Name, file.TitleID, file.Version, ext)
 	return path.Join(fileTitle)
@@ -143,7 +144,7 @@ func (driver *FTPDriver) getRealFilePathFromVirtual(path string) (string, bool) 
 	if err != nil {
 		return "", false
 	}
-	value, ok := driver.library.GetFileRecord(titleID, uint32(version))
+	value, ok := driver.library.FileIndex.GetFileRecord(titleID, uint32(version))
 	if !ok {
 		return "", false
 	}
@@ -157,7 +158,7 @@ func (driver *FTPDriver) Stat(ctx *ftpserver.Context, path string) (os.FileInfo,
 	}
 	if titleid, err := driver.dirPathToTitleID(path); err == nil {
 		//This is a file folder, generate faux info
-		if titleInfo, ok := driver.library.GetFilesForTitleID(titleid); ok {
+		if titleInfo, ok := driver.library.FileIndex.GetFilesForTitleID(titleid); ok {
 			files := titleInfo.GetFiles()
 			if len(files) > 0 {
 				return driver.getFakeFolderFileInfo(files[0]), err

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -61,9 +61,9 @@ type Settings struct {
 	CompressionEnabled bool   `json:"compressionEnabled"` // Should files be converted to their compressed verions
 
 	// Misc
-	LogLevel    int    `json:"logLevel"` // Log level, higher numbers reduce log output
-	LogFilePath string `json:"logPath"`  // Path to persist logs to, if empty none are persisted
-
+	LogLevel    int    `json:"logLevel"`    // Log level, higher numbers reduce log output
+	LogFilePath string `json:"logPath"`     // Path to persist logs to, if empty none are persisted
+	QueueLength int    `json:"queueLength"` // How deep our internal queues are
 	// Private
 	filePath string
 	logFile  *os.File
@@ -74,35 +74,34 @@ type Settings struct {
 func NewSettings(path string) *Settings {
 
 	settings := &Settings{
-		filePath:                path,
-		PreferredLangOrder:      []int{1, 0},
-		FoldersToScan:           []string{"./incoming_files"},                                         // Search locations
-		JSONLocations:           []string{},                                                           // Locations in the json to point to backup instances
-		StorageFolder:           "./game_library",                                                     // Storage location
-		CacheFolder:             "/tmp/",                                                              // Where to cache downloaded files to (titledb)
-		EnableSorting:           false,                                                                // default "safe"
-		CleanupEmptyFolders:     true,                                                                 // Relatively safe
-		HTTPPort:                8080,                                                                 // Ports
-		FTPPort:                 2121,                                                                 // Ports
-		ServerMOTD:              "Switchroot",                                                         // MOTD to include in the json file
-		LogLevel:                1,                                                                    // Info
-		LogFilePath:             "",                                                                   // No log file
-		OrganisationFormat:      "{TitleName}/{TitleName} {Type} {VersionDec} [{TitleID}][{Version}]", // Path used for organising files
-		NSZCommandLine:          "nsz --verify -w -C -p -t 4 --rm-source ",                            // NSZ command used for file compression
-		CompressionEnabled:      false,                                                                // Should files be compressed using NSZ
-		PreferCompressed:        true,                                                                 // Should compressed files be preferred over non-compressed on duplicate
-		PreferXCI:               false,                                                                // Should XCI files be preferred over nsp on duplicate
-		UploadingAllowed:        false,                                                                // Should FTP allow file uploads
-		Deduplicate:             false,                                                                // Should the software delete duplicate files
-		AllowAnonFTP:            false,                                                                // Should anon users be allowed FTP access
-		AllowAnonHTTP:           false,                                                                // Should anon users be allowed HTTP access
-		DeleteValidationFails:   false,                                                                //
-		logFile:                 nil,                                                                  // Optional path to a file to log to
-		TempFilesFolder:         "/tmp",                                                               // Temp files location used for staging FTP uploads
-		ValidateLibrary:         false,                                                                // Should all existing library files be validated
-		ValidateNewFiles:        true,                                                                 // Should "new" files be validated (upload + not library)
-		ValidateCompressedFiles: true,                                                                 // Should files be validated after they have been through the compressor
-
+		filePath:              path,
+		PreferredLangOrder:    []int{1, 0},
+		FoldersToScan:         []string{"./incoming_files"},                                         // Search locations
+		JSONLocations:         []string{},                                                           // Locations in the json to point to backup instances
+		StorageFolder:         "./game_library",                                                     // Storage location
+		CacheFolder:           "/tmp/",                                                              // Where to cache downloaded files to (titledb)
+		EnableSorting:         false,                                                                // default "safe"
+		CleanupEmptyFolders:   true,                                                                 // Relatively safe
+		HTTPPort:              8080,                                                                 // Ports
+		FTPPort:               2121,                                                                 // Ports
+		ServerMOTD:            "Switchroot",                                                         // MOTD to include in the json file
+		LogLevel:              1,                                                                    // Info
+		LogFilePath:           "",                                                                   // No log file
+		OrganisationFormat:    "{TitleName}/{TitleName} {Type} {VersionDec} [{TitleID}][{Version}]", // Path used for organising files
+		NSZCommandLine:        "nsz --verify -w -C -p -t 4 --rm-source ",                            // NSZ command used for file compression
+		CompressionEnabled:    false,                                                                // Should files be compressed using NSZ
+		PreferCompressed:      true,                                                                 // Should compressed files be preferred over non-compressed on duplicate
+		PreferXCI:             false,                                                                // Should XCI files be preferred over nsp on duplicate
+		UploadingAllowed:      false,                                                                // Should FTP allow file uploads
+		Deduplicate:           false,                                                                // Should the software delete duplicate files
+		AllowAnonFTP:          false,                                                                // Should anon users be allowed FTP access
+		AllowAnonHTTP:         false,                                                                // Should anon users be allowed HTTP access
+		DeleteValidationFails: false,                                                                //
+		logFile:               nil,                                                                  // Optional path to a file to log to
+		TempFilesFolder:       "/tmp",                                                               // Temp files location used for staging FTP uploads
+		ValidateLibrary:       false,                                                                // Should all existing library files be validated
+		ValidateNewFiles:      true,                                                                 // Should "new" files be validated (upload + not library)
+		QueueLength:           128,                                                                  // Default to a medium sized queue. Large values are good for speed but consume ram
 		//Add a demo account
 		Users: []AuthUser{
 			{

--- a/webui/index.go
+++ b/webui/index.go
@@ -16,7 +16,7 @@ func (web *WebUI) RenderGameListing(writer io.Writer) error {
 	}
 
 	i := 0
-	for _, game := range web.lib.ListTitleFiles() {
+	for _, game := range web.lib.FileIndex.ListTitleFiles() {
 		if i > 0 && i%4 == 0 {
 			if _, err := writer.Write([]byte(`</div><div class="row">`)); err != nil {
 				return ErrBadTemplate


### PR DESCRIPTION
Pulls out the index to be race-safe and also means that with some careful locking we can run multiple file-sort operations at once