### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,4 +1,6 @@
 name: Build Release assets
+permissions:
+  contents: write
 on:
   release:
     types: [created]

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,6 @@
 name: docker-build-publish
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,7 @@
 on: [push, pull_request]
 name: Unit Tests
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Ralim/switchhost/security/code-scanning/4](https://github.com/Ralim/switchhost/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly define the least privileges required for the workflow. Since the workflow does not modify repository contents, we will set `contents: read` permissions. This ensures that the workflow can read repository contents but cannot make any changes.

The `permissions` block will be added after the `name` field and before the `on` field in the `.github/workflows/docker.yml` file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
